### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,18 @@
 
 #### Data
 - The data is annotated by using `annotate_ws.py` which is based on [`annotate.py`](https://github.com/salesforce/WikiSQL) from WikiSQL repository. The tokens of natural language guery, and the start and end indices of where-conditions on natural language tokens are annotated.
-- Pre-trained BERT parameters can be downloaded from BERT [official repository](https://github.com/google-research/bert) and can be coverted to `pt`file following instruction from [huggingface-pytorch-pretrained-BERT](https://github.com/huggingface/pytorch-pretrained-BERT).
+- Pre-trained BERT parameters can be downloaded from BERT [official repository](https://github.com/google-research/bert) and can be coverted to `pt`file using following script. You need install both pytorch and tensorflow and change `BERT_BASE_DIR` to your data directory.
+
+```sh
+cd sqlova
+export BERT_BASE_DIR=data/uncased_L-12_H-768_A-12
+python bert/convert_tf_checkpoint_to_pytorch.py \
+    --tf_checkpoint_path $BERT_BASE_DIR/bert_model.ckpt \
+    --bert_config_file    $BERT_BASE_DIR/bert_config.json \
+    --pytorch_dump_path     $BERT_BASE_DIR/pytorch_model.bin 
+```
+
+`bert/convert_tf_checkpoint_to_pytorch.py` is inspired by [huggingface-pytorch-pretrained-BERT](https://github.com/huggingface/pytorch-pretrained-BERT), but `pytorch-pretrained-BERT` is not compatible with our bert model.
 - For the conveinience, the annotated WikiSQL data and the PyTorch-converted pre-trained BERT parameters are available at [here](https://drive.google.com/file/d/1iJvsf38f16el58H4NPINQ7uzal5-V4v4/view?usp=sharing).
 
 ### License


### PR DESCRIPTION
Using pytorch-pretrained-BERT to convert tensorflow ckpt file to pytorch pt file is not working. It changes state_dict key from `*.LayerNorm.beta` and `*.LayerNorm.gamma` to `*.LayerNorm.weight` and `*.LayerNorm.bias`. Also it changes dimensions somehow.

`bert/convert_tf_checkpoint_to_pytorch.py` doesn't have problems above. I spent two hours to learn that.