### PR TITLE
Make the API calls compatible with Stanza mainline

### DIFF
--- a/annotate_ws.py
+++ b/annotate_ws.py
@@ -5,7 +5,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 import os
 import records
 import ujson as json
-from stanza.nlp.corenlp import CoreNLPClient
+from stanza.server.client import CoreNLPClient
 from tqdm import tqdm
 import copy
 from wikisql.lib.common import count_lines, detokenize
@@ -20,11 +20,11 @@ def annotate(sentence, lower=True):
     if client is None:
         client = CoreNLPClient(default_annotators='ssplit,tokenize'.split(','))
     words, gloss, after = [], [], []
-    for s in client.annotate(sentence):
-        for t in s:
-            words.append(t.word)
-            gloss.append(t.originalText)
-            after.append(t.after)
+    s = client.annotate(sentence).sentence[0]
+    for t in s.token:
+        words.append(t.word)
+        gloss.append(t.originalText)
+        after.append(t.after)
     if lower:
         words = [w.lower() for w in words]
     return {


### PR DESCRIPTION
The `CoreNLPClient` import and the annotation response structure used in the current code does not work with Stanza API. This commit makes the annotation code compatible with Stanza mainline.